### PR TITLE
Revert "Update quay.io/operator-framework/catalogd Docker tag to v1.18.0"

### DIFF
--- a/olm/operator-controller.yaml
+++ b/olm/operator-controller.yaml
@@ -1556,7 +1556,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: quay.io/operator-framework/catalogd:v1.18.0@sha256:e5c91245e298902f37a8be2f43a2e78989285663f42514baff1ace10ac1c7864
+          image: quay.io/operator-framework/catalogd:v1.4.0@sha256:99ed09fee91874849d0f03015bfb7f79c3c5a29d219ba47d3ce19af5f2d46696
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Reverts dudeofawesome/doa-cluster-flux#33

Looks like olm may need to be upgraded with this