### PR TITLE
Validate image builds in pull requests and update Keycloak image digest

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,6 +1,12 @@
 name: Build images
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - images/cups/**
+      - images/keycloak/**
+      - .github/workflows/build-images.yaml
   push:
     branches: [main]
     paths:
@@ -82,6 +88,7 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -94,7 +101,7 @@ jobs:
           context: images/${{ matrix.image }}
           file: images/${{ matrix.image }}/Containerfile
           platforms: ${{ matrix.platforms }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           provenance: true
           build-args: |
             ${{ matrix.version_arg }}=${{ steps.version.outputs.image_ref }}

--- a/images/keycloak/Containerfile
+++ b/images/keycloak/Containerfile
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=quay.io/keycloak/keycloak
-ARG KC_VERSION=26.7.2@sha256:831330513f55695572286e521f94fcd3c7e285250ed5b848090265a33192f669
+ARG KC_VERSION=26.7.2@sha256:9d1f1b2b7261ff53c66cb1092dfcdc34a5fb77e81f9e6a6e75b8b6a795de8067
 FROM quay.io/keycloak/keycloak:${KC_VERSION} AS builder
 
 ENV KC_DB=postgres


### PR DESCRIPTION
### Motivation

- Ensure dependency updates (such as the Keycloak digest bump) can be built and validated in pull requests before merging. 
- Prevent accidental publishing or authenticating to the registry from untrusted pull-request runs. 

### Description

- Update `images/keycloak/Containerfile` to set `ARG KC_VERSION=26.7.2@sha256:9d1f1b2b7261ff53c66cb1092dfcdc34a5fb77e81f9e6a6e75b8b6a795de8067`. 
- Add a `pull_request` trigger to `.github/workflows/build-images.yaml` for `images/cups/**`, `images/keycloak/**`, and the workflow file itself so PRs touching image definitions run the workflow. 
- Add conditionals in `.github/workflows/build-images.yaml` to skip GHCR login (`if: github.event_name != 'pull_request'`) and to avoid pushing images during pull-request events (`push: ${{ github.event_name != 'pull_request' }}`). 

### Testing

- Ran `git diff --check` and it reported no problems. 
- Ran `npx prettier --check .github/workflows/build-images.yaml` and formatting for the modified workflow file passed. 
- Running `npx prettier --check` against `images/keycloak/Containerfile` produced a "No parser could be inferred" message for the Containerfile but did not block the workflow file validation. 
- Attempts to run an image/digest inspection via the repository `devenv` and to verify `gh` authentication failed because `devenv` is unavailable in this environment and the GitHub CLI is not authenticated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a90d4d89d38832a90e129d2c5426068)